### PR TITLE
Add replacer for Amazon links

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -12,17 +12,25 @@ import (
 
 var replacers []replacer
 
+var (
+	amazonReplacer = &genericReplacer{
+		regex:       regexp.MustCompile(`https?:\/\/(.*)\.amazon\.(de|com|co\.uk).*\/dp\/(\w*)`),
+		replacement: "https://$1.amazon.$2/dp/$3",
+	}
+	twitterReplacer = &genericReplacer{
+		regex:       regexp.MustCompile(`https?:\/\/(?P<tld>twitter)\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)`),
+		replacement: "https://fxtwitter.com/$2/status/$4",
+	}
+	discordReplacer = &genericReplacer{
+		regex:       regexp.MustCompile(`https?:\/\/media\.discordapp\.net/attachments/(\d+)/(\d+)/(.*)`),
+		replacement: "https://cdn.discordapp.com/attachments/$1/$2/$3",
+	}
+)
+
 func init() {
-	replacers = append(replacers,
-		&genericReplacer{
-			regex:       regexp.MustCompile(`https?:\/\/(?P<tld>twitter)\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)`),
-			replacement: "https://fxtwitter.com/$2/status/$4",
-		},
-		&genericReplacer{
-			regex:       regexp.MustCompile(`https?:\/\/media\.discordapp\.net/attachments/(\d+)/(\d+)/(.*)`),
-			replacement: "https://cdn.discordapp.com/attachments/$1/$2/$3",
-		},
-	)
+	replacers = append(replacers, amazonReplacer)
+	replacers = append(replacers, twitterReplacer)
+	replacers = append(replacers, discordReplacer)
 }
 
 type replacer interface {

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -1,15 +1,52 @@
 package main
 
 import (
-	"regexp"
+	"fmt"
 	"testing"
 )
 
-func TestDiscordRegex(t *testing.T) {
-	replacer := &genericReplacer{
-		regex:       regexp.MustCompile(`https?:\/\/media\.discordapp\.net/attachments/(\d+)/(\d+)/(.*)`),
-		replacement: "https://cdn.discordapp.com/attachments/$1/$2/$3",
+func TestAmazonRegex(t *testing.T) {
+	tests := []struct {
+		want string
+		have string
+	}{
+		{
+			have: "https://www.amazon.com/dp/B09B1HMJ9Z/ref=as_li_ss_tl?ie=UTF8&smid=ATVPDKIKX0DER&th=1&linkCode=sl1&tag=sec2002-20",
+			want: "https://www.amazon.com/dp/B09B1HMJ9Z",
+		},
+		{
+			have: "https://www.amazon.co.uk/dp/B09B1HMJ9Z/ref=as_li_ss_tl?ie=UTF8&smid=ATVPDKIKX0DER&th=1&linkCode=sl1&tag=sec2002-20",
+			want: "https://www.amazon.co.uk/dp/B09B1HMJ9Z",
+		},
+
+		{
+			have: "https://www.amazon.de/dp/B09B1HMJ9Z/ref=as_li_ss_tl?ie=UTF8&smid=ATVPDKIKX0DER&th=1&linkCode=sl1&tag=sec2002-20",
+			want: "https://www.amazon.de/dp/B09B1HMJ9Z",
+		},
+		{
+			have: "https://www.amazon.com/Monster-High-School-Playset/dp/B006O6F932/ref=gbph_tit_e-7_fb02_85d3d028?smid=A3CXJV2JYTL237&pf_rd_p=8e268714-ad3d-444b-b0df-d51d8825fb02&pf_rd_s=events-center-c-7&pf_rd_t=701&pf_rd_i=HTL_desktop&pf_rd_m=ATVPDKIKX0DER&pf_rd_r=8MKN8SY6C5ZP4NC1C0RB",
+			want: "https://www.amazon.com/dp/B006O6F932",
+		},
+		{
+			have: `https://www.amazon.com/Monster-High-School-Playset/dp/B006O6F932/ref=gbph_tit_e-7_fb02_85d3d028?smid=A3CXJV2JYTL237&pf_rd_p=8e268714-ad3d-444b-b0df-d51d8825fb02&pf_rd_s=events-center-c-7&pf_rd_t=701&pf_rd_i=HTL_desktop&pf_rd_m=ATVPDKIKX0DER&pf_rd_r=8MKN8SY6C5ZP4NC1C0RB
+https://www.amazon.com/Monster-High-School-Playset/dp/B006O6F932/ref=gbph_tit_e-7_fb02_85d3d028?smid=A3CXJV2JYTL237&pf_rd_p=8e268714-ad3d-444b-b0df-d51d8825fb02&pf_rd_s=events-center-c-7&pf_rd_t=701&pf_rd_i=HTL_desktop&pf_rd_m=ATVPDKIKX0DER&pf_rd_r=8MKN8SY6C5ZP4NC1C0RB
+https://www.amazon.com/Monster-High-School-Playset/dp/B006O6F932/ref=gbph_tit_e-7_fb02_85d3d028?smid=A3CXJV2JYTL237&pf_rd_p=8e268714-ad3d-444b-b0df-d51d8825fb02&pf_rd_s=events-center-c-7&pf_rd_t=701&pf_rd_i=HTL_desktop&pf_rd_m=ATVPDKIKX0DER&pf_rd_r=8MKN8SY6C5ZP4NC1C0RB`,
+			want: `https://www.amazon.com/dp/B006O6F932
+https://www.amazon.com/dp/B006O6F932
+https://www.amazon.com/dp/B006O6F932`,
+		},
 	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			if got := amazonReplacer.Replace(tt.have); got != tt.want {
+				t.Fatalf("%s != %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscordRegex(t *testing.T) {
 	tests := []struct {
 		want string
 		have string
@@ -23,9 +60,9 @@ func TestDiscordRegex(t *testing.T) {
 		//https://cdn.discordapp.com/attachments/735399993485033472/1065376405921222686/v12044gd0000cf3g5rrc77u1ikgnhp8g.mp4
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.have, func(t *testing.T) {
-			if got := replacer.Replace(tt.have); got != tt.want {
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			if got := discordReplacer.Replace(tt.have); got != tt.want {
 				t.Fatalf("%s != %s", got, tt.want)
 			}
 		})
@@ -33,8 +70,6 @@ func TestDiscordRegex(t *testing.T) {
 }
 
 func TestTwitterRegex(t *testing.T) {
-	replacer := &genericReplacer{regex: regexp.MustCompile(`https?:\/\/(?P<tld>twitter)\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)`), replacement: "https://fxtwitter.com/$2/status/$4"}
-
 	tests := []struct {
 		want string
 		have string
@@ -56,9 +91,9 @@ func TestTwitterRegex(t *testing.T) {
 			want: "https://fxtwitter.com/blablabla/status/12345678910",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.have, func(t *testing.T) {
-			if got := replacer.Replace(tt.have); got != tt.want {
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			if got := twitterReplacer.Replace(tt.have); got != tt.want {
 				t.Fatalf("%s != %s", got, tt.want)
 			}
 		})


### PR DESCRIPTION
* Add replacer for Amazon links, removing all unneccesary information
* Move all replacers into a global var block to reduce duplicate code