### PR TITLE
Move away from config singleton

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,48 +1,12 @@
+use std::env::VarError;
+use config::{Config, ConfigError};
 
-use std::path::Path;
-use std::sync::mpsc::channel;
-use std::sync::RwLock;
-use std::time::Duration;
-use config::{Config, File};
-use lazy_static::lazy_static;
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+pub fn create() -> Result<Config, ConfigError> {
+    let file_path = std::env::var("BOT_CONFIG_PATH").unwrap_or_else(|_| { "./config.yaml".to_string() });
 
-lazy_static! {
-    pub static ref SETTINGS: RwLock<Config> = RwLock::new(
-        {
-            let settings = Config::builder().add_source(File::with_name(&CONFIG_PATH));
-
-
-            settings.build().unwrap()
-        }
-    );
-
-    pub static ref CONFIG_PATH: String = {
-        match std::env::var("BOT_CONFIG_FILE") {
-            Ok(result) => {result},
-            Err(_) => {"./config.yaml".to_string()}
-        }
-    };
-}
-
-
-
-pub fn start_watcher() {
-    let (tx, rx) = channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, notify::Config::default().with_poll_interval(Duration::from_secs(2))).unwrap();
-    watcher.watch(Path::new(&CONFIG_PATH.clone().to_string()), RecursiveMode::NonRecursive).unwrap();
-    loop {
-        #[allow(deprecated)] match rx.recv() {
-            Ok(Ok(Event { kind: notify::event::EventKind::Modify(_), .. })) => {
-                println!("{} updated, refreshing config", &CONFIG_PATH.clone().to_string());
-                SETTINGS.write().unwrap().refresh().unwrap();
-
-                print_config()
-            }
-            Err(_) => {}
-            _ => {}
-        }
+    match Config::builder().add_source(config::File::with_name(file_path.as_str())).build() {
+        Ok(config) => Ok(config),
+        Err(err) => Err(err),
     }
 }
 
-pub fn print_config() {}

--- a/src/discordbot/mod.rs
+++ b/src/discordbot/mod.rs
@@ -1,12 +1,14 @@
 mod event_handler;
 
 
+use std::sync::Arc;
 use anyhow::{bail};
+use config::Config;
 use serenity::all::{GatewayIntents};
 use serenity::prelude::*;
 use crate::discordbot::event_handler::Handler;
 
-pub async fn create_client() -> anyhow::Result<Client> {
+pub async fn create_client(config: Arc<Config>) -> anyhow::Result<Client> {
     let token = match std::env::var("BOT_TOKEN") {
         Ok(token) => token,
         Err(err) => bail!("failed to read BOT_TOKEN environment variable: {}", err)
@@ -14,7 +16,8 @@ pub async fn create_client() -> anyhow::Result<Client> {
 
     let intents = GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_PRESENCES;
 
-    let client = Client::builder(token, intents).event_handler(Handler).await?;
+    let handler = Handler::new(config);
+    let client = Client::builder(token, intents).event_handler(handler).await?;
 
     Ok(client)
 }


### PR DESCRIPTION
We now pass around an Arc<Config> instead of using a static singleton for our Config.

This should not need a Mutex/RwLock, seeing as there's no writing happening.