### PR TITLE
Replace Reddit links with vxreddit instead of rxddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Message embeds are hidden when possible.
   for now)
 - [Amazon](#amazon) product links are trimmed down to the bare minimum required to visit the product page (hides link
   embed)
-- [Reddit](#reddit) links are trimmed of trackers, and replaced with rxddit
+- [Reddit](#reddit) links are trimmed of trackers, and replaced with vxreddit
 - [Instagram](#instagram) links are embedded using kkinstagram.com, removing any link trackers (only works for reels)
 - [TikTok](#tiktok) links are stripped of trackers and embedded
 
@@ -64,7 +64,7 @@ https://www.reddit.com/r/truetf2/comments/107nizk/what_makes_a_lot_of_the_config
 Turns into
 
 ```
-https://rxddit.com/r/truetf2/comments/107nizk/what_makes_a_lot_of_the_configuration/
+https://vxreddit.com/r/truetf2/comments/107nizk/what_makes_a_lot_of_the_configuration/
 ```
 
 #### Instagram

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ replacers:
     bad_url_match: http(s)?://((old|www)\.)?reddit\.com/over18.*
     post_replacement:
       - replace: www.reddit.com/r/
-        with: &reddit_replacement rxddit.com/r/
+        with: &reddit_replacement vxreddit.com/r/
       - replace: old.reddit.com/r/
         with: *reddit_replacement
       - replace: reddit.com/r/
@@ -153,17 +153,17 @@ tests:
   - replacer_name: *reddit
     tests:
       - have: https://www.reddit.com/r/WTF/comments/17j3sd/this_crawled_into_one_of_my_students_pool_and_she/c867wpi/#c867wpi
-        want: https://rxddit.com/r/WTF/comments/17j3sd/this_crawled_into_one_of_my_students_pool_and_she/c867wpi/
+        want: https://vxreddit.com/r/WTF/comments/17j3sd/this_crawled_into_one_of_my_students_pool_and_she/c867wpi/
       - have: https://www.reddit.com/r/reddit.com/comments/17863/two_countries_one_booming_one_struggling_which/c13
-        want: https://rxddit.com/r/reddit.com/comments/17863/two_countries_one_booming_one_struggling_which/c13/
+        want: https://vxreddit.com/r/reddit.com/comments/17863/two_countries_one_booming_one_struggling_which/c13/
       - have: https://old.reddit.com/r/switcharoo/comments/u24xnc/bond_girl_vs_james_bond/j3g066i
-        want: https://rxddit.com/r/switcharoo/comments/u24xnc/bond_girl_vs_james_bond/j3g066i
+        want: https://vxreddit.com/r/switcharoo/comments/u24xnc/bond_girl_vs_james_bond/j3g066i
       - have: https://www.reddit.com/r/truetf2/comments/107nizk/what_makes_a_lot_of_the_configuration?baba123=dafsdfasdf
-        want: https://rxddit.com/r/truetf2/comments/107nizk/
+        want: https://vxreddit.com/r/truetf2/comments/107nizk/
       - have: https://reddit.com/r/pchelp/s/GPxofho2iY/
-        want: https://rxddit.com/r/pchelp/comments/167kev4/i_kinda_messed_up_should_i_redo_it/
+        want: https://vxreddit.com/r/pchelp/comments/167kev4/i_kinda_messed_up_should_i_redo_it/
       - have: https://reddit.com/r/computers/s/BN4uCFXFyC
-        want: https://rxddit.com/r/computers/comments/16o6g5r/how_much_dose_my_pc_worth/
+        want: https://vxreddit.com/r/computers/comments/16o6g5r/how_much_dose_my_pc_worth/
       - have: https://old.reddit.com/r/nsfw # should resolve to something like https://old.reddit.com/over18?dest=https%3A%2F%2Fold.reddit.com%2Fr%2Fnsfw%2F
         want: https://old.reddit.com/r/nsfw
   - replacer_name: *twitch


### PR DESCRIPTION
## Summary

`rxddit.com` is being shut down soon, so this switches the Reddit link-follower's replacement target to `vxreddit.com` so Reddit links keep producing working embeds in Discord.

## Changes

- **`config.yaml`** — the Reddit `link-follower`'s `post_replacement` anchor `&reddit_replacement` changed from `rxddit.com/r/` → `vxreddit.com/r/`. This single anchor covers the `www.`, `old.`, and bare `reddit.com/r/` cases. Also updated the 6 `want:` test expectations in the reddit test block.
- **`README.md`** — the feature-list line and the example output URL.

## Verification

- Grep for `rxddit` across the repo → zero matches.
- `cargo test --features skip-link-followers` → **5 passed, 0 failed**, confirming the config parses correctly.
- The live reddit/tiktok link-follower tests aren't runnable in CI-less sandboxes (they make real outbound requests), but the reddit test's expected output now correctly reads `vxreddit.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGvUvy3D3ZoV9pnpXF9Ld8)_